### PR TITLE
localResource check if HtmlFile

### DIFF
--- a/src/main/groovy/org/aim42/htmlsanitycheck/check/MissingLocalResourcesChecker.groovy
+++ b/src/main/groovy/org/aim42/htmlsanitycheck/check/MissingLocalResourcesChecker.groovy
@@ -5,6 +5,7 @@ import org.aim42.htmlsanitycheck.html.URLUtil
 import org.aim42.htmlsanitycheck.collect.SingleCheckResults
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.aim42.filesystem.FileCollector
 
 class MissingLocalResourcesChecker extends Checker {
 
@@ -73,6 +74,7 @@ class MissingLocalResourcesChecker extends Checker {
      */
     private void checkAllLocalResources( Set<String> localResources ) {
         localResources.each { localResource ->
+            if(FileCollector.isHtmlFile(localResource)) 
             checkSingleLocalResource( localResource )
         }
     }


### PR DESCRIPTION
The hrefs need to be valid html links and we should check the regex before processing the file. Noticed this when processing pages containing javacript scripts href=javascript:show(id) for example, this gives the following error :
`groovy.lang.GroovyRuntimeException: Ambiguous method overloading for method java.io.File#<init>.
Cannot resolve which method to invoke for [class java.lang.String, null] due to overlapping prototypes between:
    [class java.lang.String, class java.lang.String]
    [class java.lang.String, class java.io.File]`